### PR TITLE
Proof verification failure after serialization/deserialization

### DIFF
--- a/barnett-smart-card-protocol/Cargo.toml
+++ b/barnett-smart-card-protocol/Cargo.toml
@@ -15,9 +15,9 @@ ark-serialize = "0.3.0"
 ark-std = { version = "0.3.0", features = ["std"] }
 blake2 = { version = "0.9", default-features = false }
 merlin = "3.0.0"
-proof-essentials = { git = "ssh://git@github.com/geometryresearch/proof-toolbox.git" }
+proof-essentials = { git = "https://git@github.com/geometryresearch/proof-toolbox.git" }
 rand = "0.8.4"
-starknet-curve = { git = "ssh://git@github.com/geometryresearch/proof-toolbox.git" }
+starknet-curve = { git = "https://git@github.com/geometryresearch/proof-toolbox.git" }
 thiserror = "1.0.30"
 
 [dev-dependencies]

--- a/barnett-smart-card-protocol/src/discrete_log_cards/mod.rs
+++ b/barnett-smart-card-protocol/src/discrete_log_cards/mod.rs
@@ -2,11 +2,15 @@ use super::BarnettSmartProtocol;
 use super::{Mask, Remask, Reveal};
 
 use crate::error::CardProtocolError;
+use ark_serialize::Read;
+use ark_serialize::Write;
+use ark_serialize::SerializationError;
 
 use anyhow::Result;
 use ark_ec::{AffineCurve, ProjectiveCurve};
 use ark_ff::{to_bytes, One, PrimeField, ToBytes};
 use ark_marlin::rng::FiatShamirRng;
+use ark_serialize::{CanonicalDeserialize, CanonicalSerialize};
 use ark_std::rand::Rng;
 use ark_std::Zero;
 use blake2::Blake2s;
@@ -34,6 +38,7 @@ pub struct DLCards<'a, C: ProjectiveCurve> {
     _group: &'a PhantomData<C>,
 }
 
+#[derive(CanonicalDeserialize, CanonicalSerialize)]
 pub struct Parameters<C: ProjectiveCurve> {
     m: usize,
     n: usize,

--- a/barnett-smart-card-protocol/src/discrete_log_cards/tests.rs
+++ b/barnett-smart-card-protocol/src/discrete_log_cards/tests.rs
@@ -11,6 +11,7 @@ mod test {
     use proof_essentials::utils::rand::sample_vector;
     use rand::thread_rng;
     use std::iter::Iterator;
+    use ark_serialize::{CanonicalDeserialize, CanonicalSerialize};
 
     // Choose elliptic curve setting
     type Curve = starknet_curve::Projective;
@@ -56,8 +57,12 @@ mod test {
         let (pk, sk) = CardProtocol::player_keygen(rng, &parameters).unwrap();
         let player_name = b"Alice";
 
-        let p1_keyproof =
+        let mut p1_keyproof =
             CardProtocol::prove_key_ownership(rng, &parameters, &pk, &sk, &player_name).unwrap();
+
+        let mut data = Vec::with_capacity(p1_keyproof.serialized_size());
+        p1_keyproof.serialize(&mut data).unwrap();
+        p1_keyproof = CanonicalDeserialize::deserialize(data.as_slice()).unwrap();
 
         assert_eq!(
             Ok(()),


### PR DESCRIPTION
Background:

I'm trying to provide mental poker APIs for Web3 games where proof verification needs to be done on the chain. We chose to expose the group of APIs thru precompiled smart contract (written in Rust) so that game contracts can simply call these APIs to verify key ownership, shuffling, reveal token, etc.

We started our test on key ownership verification and we needed to serialize and send the proof (included in a transaction) to the verification contract. We soon got stuck in an situation where we don't know how to correctly serialize and send the key ownership proof so that the smart contract (when it receives) can get it deserialized and successfully verified.

In the modified test case, it feels to me that the serialization probably doesn't extract full information of the proof and results in failure of verification (of key ownership).

Conclusion: How to correctly serialize a proof (key ownership, shuffling, reveal) when using the mental-poker library?