### PR TITLE
Masking and Reveal Token proof verifications failed after serialization/deserialization

### DIFF
--- a/barnett-smart-card-protocol/Cargo.toml
+++ b/barnett-smart-card-protocol/Cargo.toml
@@ -15,9 +15,9 @@ ark-serialize = "0.3.0"
 ark-std = { version = "0.3.0", features = ["std"] }
 blake2 = { version = "0.9", default-features = false }
 merlin = "3.0.0"
-proof-essentials = { git = "ssh://git@github.com/geometryresearch/proof-toolbox.git" }
+proof-essentials = { git = "https://github.com/geometryresearch/proof-toolbox.git" }
 rand = "0.8.4"
-starknet-curve = { git = "ssh://git@github.com/geometryresearch/proof-toolbox.git" }
+starknet-curve = { git = "https://github.com/geometryresearch/proof-toolbox.git" }
 thiserror = "1.0.30"
 
 [dev-dependencies]

--- a/barnett-smart-card-protocol/src/discrete_log_cards/masking.rs
+++ b/barnett-smart-card-protocol/src/discrete_log_cards/masking.rs
@@ -25,6 +25,8 @@ mod test {
     use crate::BarnettSmartProtocol;
 
     use ark_ff::UniformRand;
+    use ark_serialize::CanonicalDeserialize;
+    use ark_serialize::CanonicalSerialize;
     use ark_std::{rand::Rng, Zero};
     use proof_essentials::error::CryptoError;
     use proof_essentials::zkp::proofs::chaum_pedersen_dl_equality;
@@ -76,8 +78,12 @@ mod test {
         let some_card = Card::rand(rng);
         let some_random = Scalar::rand(rng);
 
-        let (masked, masking_proof): (MaskedCard, MaskingProof) =
+        let (masked, mut masking_proof): (MaskedCard, MaskingProof) =
             CardProtocol::mask(rng, &parameters, &aggregate_key, &some_card, &some_random).unwrap();
+
+        let mut data = Vec::with_capacity(masking_proof.serialized_size());
+        masking_proof.serialize(&mut data).unwrap();
+        masking_proof = CanonicalDeserialize::deserialize(data.as_slice()).unwrap();
 
         assert_eq!(
             Ok(()),

--- a/barnett-smart-card-protocol/src/discrete_log_cards/reveal.rs
+++ b/barnett-smart-card-protocol/src/discrete_log_cards/reveal.rs
@@ -25,6 +25,8 @@ mod test {
     use crate::BarnettSmartProtocol;
 
     use ark_ff::UniformRand;
+    use ark_serialize::CanonicalDeserialize;
+    use ark_serialize::CanonicalSerialize;
     use proof_essentials::error::CryptoError;
     use proof_essentials::zkp::proofs::chaum_pedersen_dl_equality;
     use rand::thread_rng;
@@ -52,9 +54,13 @@ mod test {
 
         let some_masked_card = MaskedCard::rand(rng);
 
-        let (reveal_token, reveal_proof): (RevealToken, RevealProof) =
+        let (reveal_token, mut reveal_proof): (RevealToken, RevealProof) =
             CardProtocol::compute_reveal_token(rng, &parameters, &sk, &pk, &some_masked_card)
                 .unwrap();
+
+        let mut data = Vec::with_capacity(reveal_proof.serialized_size());
+        reveal_proof.serialize(&mut data).unwrap();
+        reveal_proof = CanonicalDeserialize::deserialize(data.as_slice()).unwrap();
 
         assert_eq!(
             Ok(()),


### PR DESCRIPTION
Background:
The failures are similar to https://github.com/geometryresearch/mental-poker/pull/11 but happened on both proof of Masking and proof of Reveal Token.